### PR TITLE
Adding HTML Doctype for W3C Compliance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <!-- Put your templates and contents here -->


### PR DESCRIPTION
CMS is missing crucial W3C Compliance facilities.

This adds them in, defaulting to the defacto HTML5 standard.
